### PR TITLE
Enable macOS build

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,16 +8,16 @@ jobs:
     vmImage: ubuntu-16.04
   strategy:
     matrix:
-      linux_python3.6.____cpython:
-        CONFIG: linux_python3.6.____cpython
+      linux_python3.6.____cpythontarget_platformlinux-64:
+        CONFIG: linux_python3.6.____cpythontarget_platformlinux-64
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_python3.7.____cpython:
-        CONFIG: linux_python3.7.____cpython
+      linux_python3.7.____cpythontarget_platformlinux-64:
+        CONFIG: linux_python3.7.____cpythontarget_platformlinux-64
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_python3.8.____cpython:
-        CONFIG: linux_python3.8.____cpython
+      linux_python3.8.____cpythontarget_platformlinux-64:
+        CONFIG: linux_python3.8.____cpythontarget_platformlinux-64
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
     maxParallel: 8

--- a/.ci_support/linux_python3.6.____cpythontarget_platformlinux-64.yaml
+++ b/.ci_support/linux_python3.6.____cpythontarget_platformlinux-64.yaml
@@ -1,0 +1,42 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '7'
+ncurses:
+- '6.1'
+pin_run_as_build:
+  ncurses:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+readline:
+- '8.0'
+target_platform:
+- linux-64
+xz:
+- '5.2'
+zlib:
+- '1.2'

--- a/.ci_support/linux_python3.7.____cpythontarget_platformlinux-64.yaml
+++ b/.ci_support/linux_python3.7.____cpythontarget_platformlinux-64.yaml
@@ -1,0 +1,42 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '7'
+ncurses:
+- '6.1'
+pin_run_as_build:
+  ncurses:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+readline:
+- '8.0'
+target_platform:
+- linux-64
+xz:
+- '5.2'
+zlib:
+- '1.2'

--- a/.ci_support/linux_python3.8.____cpythontarget_platformlinux-64.yaml
+++ b/.ci_support/linux_python3.8.____cpythontarget_platformlinux-64.yaml
@@ -31,9 +31,11 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.8.* *_cpython
 readline:
 - '8.0'
+target_platform:
+- linux-64
 xz:
 - '5.2'
 zlib:

--- a/.ci_support/osx_python3.6.____cpythontarget_platformosx-64.yaml
+++ b/.ci_support/osx_python3.6.____cpythontarget_platformosx-64.yaml
@@ -1,24 +1,36 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '7'
+- '9'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- '9'
+expat:
+- '2.2'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+libiconv:
+- '1.15'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 ncurses:
 - '6.1'
 pin_run_as_build:
+  expat:
+    max_pin: x.x
+  libiconv:
+    max_pin: x.x
   ncurses:
     max_pin: x.x
   python:
@@ -34,6 +46,8 @@ python:
 - 3.6.* *_cpython
 readline:
 - '8.0'
+target_platform:
+- osx-64
 xz:
 - '5.2'
 zlib:

--- a/.ci_support/osx_python3.7.____cpythontarget_platformosx-64.yaml
+++ b/.ci_support/osx_python3.7.____cpythontarget_platformosx-64.yaml
@@ -1,24 +1,36 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '7'
+- '9'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- '9'
+expat:
+- '2.2'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+libiconv:
+- '1.15'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 ncurses:
 - '6.1'
 pin_run_as_build:
+  expat:
+    max_pin: x.x
+  libiconv:
+    max_pin: x.x
   ncurses:
     max_pin: x.x
   python:
@@ -31,9 +43,11 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.7.* *_cpython
 readline:
 - '8.0'
+target_platform:
+- osx-64
 xz:
 - '5.2'
 zlib:

--- a/.ci_support/osx_python3.8.____cpythontarget_platformosx-64.yaml
+++ b/.ci_support/osx_python3.8.____cpythontarget_platformosx-64.yaml
@@ -1,0 +1,54 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
+expat:
+- '2.2'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '7'
+libiconv:
+- '1.15'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+ncurses:
+- '6.1'
+pin_run_as_build:
+  expat:
+    max_pin: x.x
+  libiconv:
+    max_pin: x.x
+  ncurses:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+readline:
+- '8.0'
+target_platform:
+- osx-64
+xz:
+- '5.2'
+zlib:
+- '1.2'

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -x
+
+echo -e "\n\nInstalling a fresh version of Miniforge."
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:start:install_miniforge\\r'
+fi
+MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
+MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
+curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
+bash $MINIFORGE_FILE -b
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:end:install_miniforge\\r'
+fi
+
+echo -e "\n\nConfiguring conda."
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:start:configure_conda\\r'
+fi
+
+source ${HOME}/miniforge3/etc/profile.d/conda.sh
+conda activate base
+
+echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
+conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+
+
+
+echo -e "\n\nSetting up the condarc and mangling the compiler."
+setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+mangle_compiler ./ ./recipe .ci_support/${CONFIG}.yaml
+
+echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
+/usr/bin/sudo mangle_homebrew
+/usr/bin/sudo -k
+
+echo -e "\n\nRunning the build setup script."
+source run_conda_forge_build_setup
+
+
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:end:configure_conda\\r'
+fi
+
+set -e
+
+echo -e "\n\nMaking the build clobber file and running the build."
+make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+validate_recipe_outputs "gdb-feedstock"
+
+if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+  echo -e "\n\nUploading the packages."
+  upload_package --validate --feedstock-name="gdb-feedstock" ./ ./recipe ./.ci_support/${CONFIG}.yaml
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+
+language: generic
+
+env:
+  global:
+    # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
+    - secure: "wuJaSX/imX8Xf5Gp1H/tFmqrx1rsNrvpUf/1SzCFku7pU1YgwzVVktUMy64APFaIGLywNyBCSeU/7wEujjutJk5SZJ3wURQusPnNZ7pbsOPFpLnbTCtLdFyXj2c/hy9cBN6elkwt+2YyIMUJJtsTlMjp0rUfw8Uq8jgk3MHChr0Jfxj7kenQeXLcpXZseCs2ucvBKIHtwp19kY95CkQ99VXfFD1lDV92SqwPuYbF0FVIMFixTHmoSPTdFbGR3HR0oGC4fXO6GiK8WjtibETq2etIaL1RaJee3ZQOpZi0F6dI05663YsEqkmnSK5e0rimLuDAzve6kBMq6SlZV20L2/Vljw0qcNr/qpAp3pb5hEP/g8dHA9jE0qq339V/XxE9we3IaRmdcX5Gou6DWE6vlen6L4WQxoJWjiwVg0viD0A8RZnIb91M9IPfM4WgHpTLpNJeWHgDul/sQROzwfk2hO97trXNu0BsUkdQXzqRxSg7p8w2Yj8v3Rar+TmAHYrj/O01vM2b01dteRZS2zZLHW+VePLB954hH57hyQ1JJw9b2y6zVxoPM8e2HotdivdIOvqLyZTIhmmJjeFyynmKwNSy2BYXzqdY8ZBnB9lxi+ELan71uD6A1AmOOx64x519VqFUTGpXH0sadstq/omBqQC9nbyQag0bJYR51tERC14="
+
+matrix:
+  include:
+    - env: CONFIG=osx_python3.6.____cpythontarget_platformosx-64 UPLOAD_PACKAGES=True PLATFORM=osx-64
+      os: osx
+      osx_image: xcode9.4
+
+    - env: CONFIG=osx_python3.7.____cpythontarget_platformosx-64 UPLOAD_PACKAGES=True PLATFORM=osx-64
+      os: osx
+      osx_image: xcode9.4
+
+    - env: CONFIG=osx_python3.8.____cpythontarget_platformosx-64 UPLOAD_PACKAGES=True PLATFORM=osx-64
+      os: osx
+      osx_image: xcode9.4
+
+script:
+  - export CI=travis
+  - export GIT_BRANCH="$TRAVIS_BRANCH"
+
+  - if [[ ${PLATFORM} =~ .*osx.* ]]; then ./.scripts/run_osx_build.sh; fi

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About gdb
 
 Home: https://www.gnu.org/software/gdb/
 
-Package license: GPL-2.0-only
+Package license: GPL-3.0-only
 
 Feedstock license: BSD 3-Clause
 
@@ -22,7 +22,14 @@ Current build status
 ====================
 
 
-<table>
+<table><tr>
+    <td>Travis</td>
+    <td>
+      <a href="https://travis-ci.com/conda-forge/gdb-feedstock">
+        <img alt="macOS" src="https://img.shields.io/travis/com/conda-forge/gdb-feedstock/master.svg?label=macOS">
+      </a>
+    </td>
+  </tr>
     
   <tr>
     <td>Azure</td>
@@ -36,36 +43,51 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_python3.6.____cpython</td>
+              <td>linux_python3.6.____cpythontarget_platformlinux-64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3908&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gdb-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gdb-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6.____cpythontarget_platformlinux-64" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.7.____cpython</td>
+              <td>linux_python3.7.____cpythontarget_platformlinux-64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3908&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gdb-feedstock?branchName=master&jobName=linux&configuration=linux_python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gdb-feedstock?branchName=master&jobName=linux&configuration=linux_python3.7.____cpythontarget_platformlinux-64" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.8.____cpython</td>
+              <td>linux_python3.8.____cpythontarget_platformlinux-64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3908&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gdb-feedstock?branchName=master&jobName=linux&configuration=linux_python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gdb-feedstock?branchName=master&jobName=linux&configuration=linux_python3.8.____cpythontarget_platformlinux-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_python3.6.____cpythontarget_platformosx-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3908&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gdb-feedstock?branchName=master&jobName=osx&configuration=osx_python3.6.____cpythontarget_platformosx-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_python3.7.____cpythontarget_platformosx-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3908&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gdb-feedstock?branchName=master&jobName=osx&configuration=osx_python3.7.____cpythontarget_platformosx-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_python3.8.____cpythontarget_platformosx-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3908&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gdb-feedstock?branchName=master&jobName=osx&configuration=osx_python3.8.____cpythontarget_platformosx-64" alt="variant">
                 </a>
               </td>
             </tr>
           </tbody>
         </table>
       </details>
-    </td>
-  </tr>
-  <tr>
-    <td>OSX</td>
-    <td>
-      <img src="https://img.shields.io/badge/OSX-disabled-lightgrey.svg" alt="OSX disabled">
     </td>
   </tr>
   <tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,5 @@
+provider:
+  osx: travis
 appveyor:
   secure: {BINSTAR_TOKEN: tumuXLL8PU75WMnRDemRy02ruEq2RpNxeK3dz0MjFssnosPm2v4EFjfNB4PTotA1}
 compiler_stack: comp7

--- a/recipe/0001-darwin-nat.c-do-not-hang-on-long-gone-thread.patch
+++ b/recipe/0001-darwin-nat.c-do-not-hang-on-long-gone-thread.patch
@@ -1,0 +1,27 @@
+From bef2be246f3d5d3681681aba0c46751a02dc4508 Mon Sep 17 00:00:00 2001
+From: Philippe Blain <levraiphilippeblain@gmail.com>
+Date: Wed, 24 Jun 2020 16:42:31 -0400
+Subject: [PATCH] darwin-nat.c: do not hang on long-gone thread
+
+See https://sourceware.org/bugzilla/show_bug.cgi?id=24069
+
+---
+ gdb/darwin-nat.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gdb/darwin-nat.c b/gdb/darwin-nat.c
+index 8c34aa8a3f..d30374b673 100644
+--- a/gdb/darwin-nat.c
++++ b/gdb/darwin-nat.c
+@@ -1151,7 +1151,7 @@ darwin_decode_message (mach_msg_header_t *hdr,
+ 			      res, wstatus);
+ 
+ 	      /* Looks necessary on Leopard and harmless...  */
+-	      wait4 (inf->pid, &wstatus, 0, NULL);
++	      wait4 (inf->pid, &wstatus, WNOHANG, NULL);
+ 
+ 	      inferior_ptid = ptid_t (inf->pid, 0, 0);
+ 	      return inferior_ptid;
+-- 
+2.26.2
+

--- a/recipe/README.md
+++ b/recipe/README.md
@@ -1,13 +1,16 @@
 Note: the macOS build uses Travis because the conda-forge Travis config uses macOS 10.13,
-and running an executable in GDB under SSH on macOS 10.14+ (including the Travis and Azure images) makes GDB hang. 
+and running an executable in GDB on macOS 10.14+ (including the Travis and Azure images) makes GDB hang about half the time. 
 
-This is probably related to the fact that some system security settings need to be adjusted
-for the debugger to be able to run unimpeded (I'm guessing that it's waiting for a graphical
-authentication popup window somehow.)
+This is probably a manifestation of this bug :
+https://sourceware.org/bugzilla/show_bug.cgi?id=24069
 
-[This person][1] suggests using an entitlement file with additional entitlements compared to the [official recommendation][2], so it could be worth investigating adding these entitlements when the 10.13 Travis image is decomissioned.
+With the included patch, GDB shows
+```
+During startup program terminated with signal ?, Unknown signal
+```
 
-Note also that building this recipe locally on macOS will fail in the test phase because the GDB executable will not be codesigned (unless your user has passwordless `sudo` permissions).
+upon `run` about half the time instead of hanging.
 
-[1]: https://timnash.co.uk/getting-gdb-to-semi-reliably-work-on-mojave-macos/
+Note also that building this recipe locally on macOS will fail in the test phase because the GDB executable will not be codesigned[2] (unless your user has passwordless `sudo` permissions).
+
 [2]: https://sourceware.org/gdb/wiki/PermissionsDarwin#Sign_and_entitle_the_gdb_binary

--- a/recipe/README.md
+++ b/recipe/README.md
@@ -1,0 +1,13 @@
+Note: the macOS build uses Travis because the conda-forge Travis config uses macOS 10.13,
+and running an executable in GDB under SSH on macOS 10.14+ (including the Travis and Azure images) makes GDB hang. 
+
+This is probably related to the fact that some system security settings need to be adjusted
+for the debugger to be able to run unimpeded (I'm guessing that it's waiting for a graphical
+authentication popup window somehow.)
+
+[This person][1] suggests using an entitlement file with additional entitlements compared to the [official recommendation][2], so it could be worth investigating adding these entitlements when the 10.13 Travis image is decomissioned.
+
+Note also that building this recipe locally on macOS will fail in the test phase because the GDB executable will not be codesigned (unless your user has passwordless `sudo` permissions).
+
+[1]: https://timnash.co.uk/getting-gdb-to-semi-reliably-work-on-mojave-macos/
+[2]: https://sourceware.org/gdb/wiki/PermissionsDarwin#Sign_and_entitle_the_gdb_binary

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Check gdb is codesigned
+if  ! codesign -vv $CONDA_PREFIX/bin/gdb > /dev/null 2>&1; then
+  echo "Warning: GDB is not codesigned."
+  cat $CONDA_PREFIX/etc/gdb/.messages.txt
+fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eu
+
 # Download the right script to debug python processes.
 # This is an useful script provided by CPython project to help debugging
 # crashes in Python processes.
@@ -29,6 +31,26 @@ gdb.events.new_objfile.connect(setup_python)
 end
 ' >> "$PREFIX/etc/gdbinit"
 
+# macOS specificities
+if [[ $target_platform == "osx-64" ]]; then
+  # prevent a VERSION file being confused by clang++ with $CONDA_PREFIX/include/c++/v1/version
+  mv intl/VERSION intl/VERSION.txt
+  # install needed scripts to generate a codesigning certificate and sign the gdb executable
+  cp $RECIPE_DIR/macos-codesign/macos-setup-codesign.sh $PREFIX/bin/
+  cp $RECIPE_DIR/macos-codesign/macos-codesign-gdb.sh   $PREFIX/bin/
+  # copy the entitlement file
+  mkdir -p $PREFIX/etc/gdb
+  cp $RECIPE_DIR/macos-codesign/gdb-entitlement.xml $PREFIX/etc/gdb/
+  # add libiconv and expat flags
+  libiconv_flag="--with-libiconv-prefix=$PREFIX"
+  expat_flag="--with-libexpat-prefix=$PREFIX"
+  # Setup the necessary GDB startup command for macOS Sierra and later
+  echo "set startup-with-shell off" >> "$PREFIX/etc/gdbinit"
+  # Copy the activate script to the installation prefix
+  mkdir -p "${PREFIX}/etc/conda/activate.d"
+  cp $RECIPE_DIR/activate.sh "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_activate.sh"
+fi
+
 export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
 # Setting /usr/lib/debug as debug dir makes it possible to debug the system's
 # python on most Linux distributions
@@ -40,6 +62,10 @@ $SRC_DIR/configure \
     --prefix="$PREFIX" \
     --with-separate-debug-dir="$PREFIX/lib/debug:/usr/lib/debug" \
     --with-python=${PYTHON} \
-    --with-system-gdbinit="$PREFIX/etc/gdbinit" || (cat config.log && exit 1)
-make -j${CPU_COUNT}  VERBOSE=1
+    --with-system-gdbinit="$PREFIX/etc/gdbinit" \
+    ${libiconv_flag:-} \
+    ${expat_flag:-} \
+    || (cat config.log && exit 1)
+make -j${CPU_COUNT} VERBOSE=1
 make install
+

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -38,6 +38,7 @@ if [[ $target_platform == "osx-64" ]]; then
   # install needed scripts to generate a codesigning certificate and sign the gdb executable
   cp $RECIPE_DIR/macos-codesign/macos-setup-codesign.sh $PREFIX/bin/
   cp $RECIPE_DIR/macos-codesign/macos-codesign-gdb.sh   $PREFIX/bin/
+  cp $RECIPE_DIR/macos-codesign/macos-show-caveats.sh   $PREFIX/bin/
   # copy the entitlement file
   mkdir -p $PREFIX/etc/gdb
   cp $RECIPE_DIR/macos-codesign/gdb-entitlement.xml $PREFIX/etc/gdb/

--- a/recipe/macos-codesign/gdb-entitlement.xml
+++ b/recipe/macos-codesign/gdb-entitlement.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.debugger</key>
+    <true/>
+</dict>
+</plist>
+</pre>

--- a/recipe/macos-codesign/macos-codesign-gdb.sh
+++ b/recipe/macos-codesign/macos-codesign-gdb.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eu
+
+# macOS specificities: codesign the GDB executable
+# Generate code-signing certificate (needs `sudo`)
+$CONDA_PREFIX/bin/macos-setup-codesign.sh
+# unset a variable set by old versions of the clang activation script that prevents using `/usr/bin/codesign`
+# (in case old builds of conda-forge compilers are installed in the installation environment)
+# see https://github.com/conda-forge/clang-compiler-activation-feedstock/issues/18
+# and https://github.com/conda-forge/clang-compiler-activation-feedstock/pull/19
+unset CODESIGN_ALLOCATE
+# Sign the GDB binary
+codesign --entitlements $CONDA_PREFIX/etc/gdb/gdb-entitlement.xml --force --sign gdb_codesign $CONDA_PREFIX/bin/gdb

--- a/recipe/macos-codesign/macos-setup-codesign.sh
+++ b/recipe/macos-codesign/macos-setup-codesign.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# This script is copied from https://github.com/llvm/llvm-project/blob/master/lldb/scripts/macos-setup-codesign.sh
+
+CERT="gdb_codesign"
+
+function error() {
+    echo error: "$@" 1>&2
+    exit 1
+}
+
+function cleanup {
+    # Remove generated files
+    rm -f "$TMPDIR/$CERT.tmpl" "$TMPDIR/$CERT.cer" "$TMPDIR/$CERT.key" > /dev/null 2>&1
+}
+
+trap cleanup EXIT
+
+# Check if the certificate is already present in the system keychain
+security find-certificate -Z -p -c "$CERT" /Library/Keychains/System.keychain > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    echo Certificate has already been generated and installed
+    exit 0
+fi
+
+# Create the certificate template
+cat <<EOF >$TMPDIR/$CERT.tmpl
+[ req ]
+default_bits       = 2048        # RSA key size
+encrypt_key        = no          # Protect private key
+default_md         = sha512      # MD to use
+prompt             = no          # Prompt for DN
+distinguished_name = codesign_dn # DN template
+[ codesign_dn ]
+commonName         = "$CERT"
+[ codesign_reqext ]
+keyUsage           = critical,digitalSignature
+extendedKeyUsage   = critical,codeSigning
+EOF
+
+echo Generating and installing gdb_codesign certificate
+
+# Generate a new certificate
+openssl req -new -newkey rsa:2048 -x509 -days 3650 -nodes -config "$TMPDIR/$CERT.tmpl" -extensions codesign_reqext -batch -out "$TMPDIR/$CERT.cer" -keyout "$TMPDIR/$CERT.key" > /dev/null 2>&1
+[ $? -eq 0 ] || error Something went wrong when generating the certificate
+
+# Install the certificate in the system keychain
+sudo security add-trusted-cert -d -r trustRoot -p codeSign -k /Library/Keychains/System.keychain "$TMPDIR/$CERT.cer" > /dev/null 2>&1
+[ $? -eq 0 ] || error Something went wrong when installing the certificate
+
+# Install the key for the certificate in the system keychain
+sudo security import "$TMPDIR/$CERT.key" -A -k /Library/Keychains/System.keychain > /dev/null 2>&1
+[ $? -eq 0 ] || error Something went wrong when installing the key
+
+# Kill task_for_pid access control daemon
+sudo pkill -f /usr/libexec/taskgated > /dev/null 2>&1
+
+# Exit indicating the certificate is now generated and installed
+exit 0

--- a/recipe/macos-codesign/macos-setup-codesign.sh.patch
+++ b/recipe/macos-codesign/macos-setup-codesign.sh.patch
@@ -1,0 +1,25 @@
+--- macos-setup-codesign.sh	2020-06-13 20:43:24.000000000 -0400
++++ recipe/macos-codesign/macos-setup-codesign.sh	2020-06-13 20:47:52.000000000 -0400
+@@ -1,9 +1,11 @@
+ #!/bin/bash
+ 
+-CERT="lldb_codesign"
++# This script is copied from https://github.com/llvm/llvm-project/blob/master/lldb/scripts/macos-setup-codesign.sh
++
++CERT="gdb_codesign"
+ 
+ function error() {
+-    echo error: "$@"
++    echo error: "$@" 1>&2
+     exit 1
+ }
+ 
+@@ -36,7 +38,7 @@
+ extendedKeyUsage   = critical,codeSigning
+ EOF
+ 
+-echo Generating and installing lldb_codesign certificate
++echo Generating and installing gdb_codesign certificate
+ 
+ # Generate a new certificate
+ openssl req -new -newkey rsa:2048 -x509 -days 3650 -nodes -config "$TMPDIR/$CERT.tmpl" -extensions codesign_reqext -batch -out "$TMPDIR/$CERT.cer" -keyout "$TMPDIR/$CERT.key" > /dev/null 2>&1

--- a/recipe/macos-codesign/macos-show-caveats.sh
+++ b/recipe/macos-codesign/macos-show-caveats.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cat $CONDA_PREFIX/etc/gdb/.messages.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: http://ftp.gnu.org/gnu/gdb/gdb-{{ version }}.tar.xz
   sha256: 360cd7ae79b776988e89d8f9a01c985d0b1fa21c767a4295e5f88cb49175c555
+  patches:
+    - 0001-darwin-nat.c-do-not-hang-on-long-gone-thread.patch
 
 build:
   number: 3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,9 +48,9 @@ test:
 
 about:
   home: https://www.gnu.org/software/gdb/
-  license: GPL-2.0-only
+  license: GPL-3.0-only
   license_family: GPL
-  license_file: COPYING
+  license_file: gdb/COPYING
   summary: GDB, the GNU Project debugger, allows you to see what is going on inside another program while it executes -- or what another program was doing at the moment it crashed.
   description: |
     GDB, the GNU Project debugger, allows you to see what is going on `inside'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,11 @@ source:
   sha256: 360cd7ae79b776988e89d8f9a01c985d0b1fa21c767a4295e5f88cb49175c555
 
 build:
-  number: 2
-  skip: True  # [win or osx]
+  number: 3
+  skip: True  # [win]
+  # needed by macOS codesigning script
+  script_env:
+   - TMPDIR
 
 requirements:
   build:
@@ -26,16 +29,22 @@ requirements:
     - xz
     - zlib
     - readline
+    - libiconv  # [osx]
+    - expat     # [osx]
   run:
     - python
     - ncurses
     - xz
     - zlib
     - six
+    - libiconv  # [osx]
+    - expat     # [osx]
 
 test:
   commands:
     - gdb --version
+  requires:
+    - {{ compiler('c') }}
 
 about:
   home: https://www.gnu.org/software/gdb/

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -eu
+
+# Returns 0 if current user is in the sudoers file
+# and sudo-ing does not require a password.
+can_sudo_without_password () {
+sudo -ln | \grep -q '(ALL) NOPASSWD: ALL'
+}
+
+# macOS specificities: codesign the GDB executable
+if [[ $(uname) == "Darwin" ]]; then
+  # On CI, sign the executable (for the tests)
+  if can_sudo_without_password; then
+    $PREFIX/bin/macos-codesign-gdb.sh
+  else
+    # Create the message shown at the end of installation
+    cat <<-EOF > $PREFIX/.messages.txt
+	
+	
+	Due to macOS security restrictions, the GDB executable 
+	needs to be codesigned to be able to control other processes.
+
+	The codesigning process requires the Command Line Tools
+	(or a full XCode installation). 
+	To install the Command Line Tools, run
+	
+	  xcode-select --install
+	
+	The codesigning process also requires administrative permissions
+	(your user must be able to run \`sudo\`).
+
+	To codesign GDB, simply run the included script:
+
+	  macos-codesign-gdb.sh
+
+	and enter your password. 
+
+	Make sure this environment, "$(basename $PREFIX)", is activated
+	so that "macos-codesign-gdb.sh" is found in your \$PATH.
+
+	For more information, see: https://sourceware.org/gdb/wiki/PermissionsDarwin
+	EOF
+    # Copy the message file since we might need to show it in the activate script
+    # and conda deletes it after displaying it
+    cp $PREFIX/.messages.txt $PREFIX/etc/gdb/.messages.txt
+  fi
+fi

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -8,6 +8,21 @@ can_sudo_without_password () {
 sudo -ln | \grep -q '(ALL) NOPASSWD: ALL'
 }
 
+# Return X in macOS version 10.X.Y
+get_macos_version () {
+sw_vers -productVersion | sed -e 's/10.\([0-9][0-9]\)\.[0-9]/\1/'
+}
+
+# Returns 0 if macOS version is Mojave or Catalina
+on_mojave_or_catalina () {
+macos_version=$(get_macos_version)
+if [ $macos_version  == '14' ] || [ $macos_version == '15' ] ; then
+  return 0
+else
+  return 1
+fi
+}
+
 # macOS specificities: codesign the GDB executable
 if [[ $(uname) == "Darwin" ]]; then
   # On CI, sign the executable (for the tests)
@@ -18,6 +33,8 @@ if [[ $(uname) == "Darwin" ]]; then
     cat <<-EOF > $PREFIX/.messages.txt
 	
 	
+	Codesigning GDB
+	---------------
 	Due to macOS security restrictions, the GDB executable 
 	needs to be codesigned to be able to control other processes.
 
@@ -40,6 +57,49 @@ if [[ $(uname) == "Darwin" ]]; then
 	so that "macos-codesign-gdb.sh" is found in your \$PATH.
 
 	For more information, see: https://sourceware.org/gdb/wiki/PermissionsDarwin
+	EOF
+    # Tell users how to avoid being prompted for their password each time they run their executable
+    cat <<-EOF >> $PREFIX/.messages.txt
+	
+	Avoiding being prompted for a password
+	--------------------------------------
+	On recent macOS versions, you will be prompted for an administrator username and password
+	the first time you \`run\` an executable in GDB in each login session.
+
+	To instead be prompted for your own password,
+	you can add your user to the '_developer' group:
+
+	  sudo dscl . merge /Groups/_developer GroupMembership $USER
+	
+	To avoid being prompted for any password, run
+
+	  sudo security authorizationdb write system.privilege.taskport allow
+
+	EOF
+    # If on Mojave or Catalina, warn users about the "Unknown signal" error
+    if on_mojave_or_catalina; then
+    cat <<-EOF >> $PREFIX/.messages.txt
+	Intermittent GDB error on Mojave and later
+	------------------------------------------
+	We've detected you are running macOS Mojave or later. GDB has a known intermittent bug on
+	recent macOS versions, see: https://sourceware.org/bugzilla/show_bug.cgi?id=24069
+
+	If you receive the following error when running your executable in GDB:
+	
+	  During startup program terminated with signal ?, Unknown signal
+	
+	simply try to \`run\` your executable again, it should work eventually.
+	EOF
+    fi
+    # Tell the user how to show this message again
+    cat <<-EOF >> $PREFIX/.messages.txt
+	
+	Showing this message again
+	--------------------------
+	Once GDB is codesigned, this message will disappear.
+	To show this message again, run
+	
+	  macos-show-caveats.sh
 	EOF
     # Copy the message file since we might need to show it in the activate script
     # and conda deletes it after displaying it

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash -ex
 
-# This test tries to simulate a crash on a python process. The process under test
+# Make sure we are not prompted for a password before running an executable in GDB on macOS
+if [[ $(uname) == "Darwin" ]]; then
+  sudo /usr/sbin/DevToolsSecurity -enable
+  sudo security authorizationdb write system.privilege.taskport allow
+fi
+
+# Run hello world test
+$CC -o hello -g "$RECIPE_DIR/testing/hello.c"
+gdb -batch -ex "run" --args hello
+
+# This next test tries to simulate a crash on a python process. The process under test
 # forces a crash by emitting a SIGSEGV signal to itself. This is similar to what
 # would happen on a python code calling a C/C++ module which causes a seg fault.
 # When that happens we should be able to use the python extensions for gdb to get
@@ -18,6 +28,13 @@
 echo "CONDA_PY:$CONDA_PY"
 export CONDA_PY=`python -c "import sys;print('%s%s'%sys.version_info[:2])"`
 echo "CONDA_PY:$CONDA_PY"
+
+if [[ $(uname) == "Darwin" ]]; then
+  # Skip python test on macOS, since the Python executable is missing debug symbols.
+  # see https://github.com/conda-forge/gdb-feedstock/pull/23/#issuecomment-643008755
+  # and https://github.com/conda-forge/python-feedstock/issues/354
+  exit 0
+fi
 
 gdb -batch -ex "run" -ex "py-bt" --args python "$RECIPE_DIR/testing/process_to_debug.py" | tee gdb_output
 if [[ "$CONDA_PY" != "27" ]]; then

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -52,7 +52,7 @@ fi
 # This list is mostly for documentation purposes, so we know exactly which versions can be
 # debugged out-of-the-box with this gdb package. When things change, there is not much to be
 # done besides adding or removing versions from this list.
-insufficient_debug_info_versions=("27" "36")
+insufficient_debug_info_versions=("36")
 
 if [[ " ${insufficient_debug_info_versions[@]} " =~ " ${CONDA_PY} " ]]; then
     if grep "line 3" gdb_output; then

--- a/recipe/testing/hello.c
+++ b/recipe/testing/hello.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+int main() {
+   printf("Hello, World!\n");
+   return 0;
+}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes #7 
<!--
Please add any other relevant info below:
-->
TODO:
- [x] activate the osx build in meta.yml
- [x] copy the script that generates the code signing certificate from https://github.com/llvm/llvm-project/blob/master/lldb/scripts/macos-setup-codesign.sh
- [x] make the build phase succeed on macOS
- [x] make the test phase succeed on macOS
- [x] make code signing work on the CI
- [x] move the code-signing script such that it ends up in the installed package.
- [x] add a script that does the actual code signing (for end-users)
- [x] add a [`post-link`](https://docs.conda.io/projects/conda-build/en/latest/resources/link-scripts.html) script that writes to `$PREFIX/.message.txt` to instruct users to run the code signing script on their machine to be able to use the debugger. (might be better to wait for conda 4.8.4: see https://github.com/conda/conda/issues/8809)
- [x] check if we need to entitle the binary for Mojave and later (https://sourceware.org/gdb/wiki/PermissionsDarwin#Sign_and_entitle_the_gdb_binary), it seems this is not done by the Makefile
- [x] see if we want to add `set startup-with-shell off ` (https://sourceware.org/gdb/wiki/BuildingOnDarwin#Disable_starting_the_debuggee_.28inferior.29_via_a_shell) to the global gdbinit, or just instruct users to add that to their `~/.gdbinit`. The latter might be less user-friendly, but easier if we want this to apply only on macOS. The alternative would be to use `--with-system-gdbinit-dir=directory` (https://sourceware.org/gdb/current/onlinedocs/gdb/System_002dwide-configuration.html#System_002dwide-configuration) and have a script for the python stuff and a separate script for macOS that gets added  inside a `if [[ $(uname) == "Darwin" ]]` block in build.sh.
- [x] add an activate script that checks if the binary is code-signed correctly, if users forgot to do it just after installing.
- [x] make the linter happy (License/SPDX message)

---

13/06/2020: here is a final description of this PR, now that all tests are passing.

## Add support for building GDB on macOS

On macOS, debuggers need to be codesigned with a codesigning certificate located in the System keychain to be able to control other processes.

The script `recipe/macos-codesign/macos-setup-codesign.sh` sets up this certificate. It is taken from the [LLDB repository][1] and only slightly modified to use "gdb_codesign" as the certificate name. Using a script seems more robust than the manual method mentioned in the [GDB wiki][2]. 
This script requires 'sudo', so it is run automatically on the CI but not in a user installation. It is copied to the installation prefix so that users can run it after installing GDB.

The script `recipe/macos-codesign/macos-codesign-gdb.sh` actually calls `macos-setup-codesign.sh` and then signs the GDB executable using the just created certificate.

A post-link script runs the `recipe/macos-codesign/macos-codesign-gdb.sh` if passwordless sudo is available (in the CI), and if it's not, it writes to `$PREFIX/.messages.txt` such that users are notified that they need to sign GDB in order to use it, using the provided script.
**Note**: at the moment, conda mangles multi-line messages in `$PREFIX/.messages.txt` (https://github.com/conda/conda/issues/8809 ). This bug was fixed in https://github.com/conda/conda/pull/9841, which is already merged, and so should appear in conda 4.8.4. Maybe we want to wait for this conda release before merging this ? It would make for a nicer end-user experience, but since this message is also shown upon environment activation (as long as GDB is not codesigned), I think it's ok.

The message shown also informs users how to avoid being prompted for a password every login when they start an executable in GDB.

An activate script is also added to make sure that GDB is correctly codesigned upon environment activation. If it's not codesigned, users are instructed to run the provided script (by showing the same message as the post-link script). 

Here is a copy of the message users will see when installing (with the fix in  https://github.com/conda/conda/pull/9841 applied to conda) :
```
Preparing transaction: done
Verifying transaction: done
Executing transaction: \ 

Codesigning GDB
---------------
Due to macOS security restrictions, the GDB executable 
needs to be codesigned to be able to control other processes.

The codesigning process requires the Command Line Tools
(or a full XCode installation). 
To install the Command Line Tools, run

  xcode-select --install

The codesigning process also requires administrative permissions
(your user must be able to run `sudo`).

To codesign GDB, simply run the included script:

  macos-codesign-gdb.sh

and enter your password. 

Make sure this environment, "<environment name>", is activated
so that "macos-codesign-gdb.sh" is found in your $PATH.

For more information, see: https://sourceware.org/gdb/wiki/PermissionsDarwin

Avoiding being prompted for a password
--------------------------------------
On recent macOS versions, you will be prompted for an administrator username and password
the first time you `run` an executable in GDB in each login session.

To instead be prompted for your own password,
you can add your user to the '_developer' group:

  sudo dscl . merge /Groups/_developer GroupMembership <username>

To avoid being prompted for any password, run

  sudo security authorizationdb write system.privilege.taskport allow


Showing this message again
--------------------------
Once GDB is codesigned, this message will disappear.
To show this message again, run

  macos-show-caveats.sh

done
#
# To activate this environment, use
#
#     $ conda activate gdb
#
# To deactivate an active environment, use
#
#     $ conda deactivate
```

Since the Python executable from the conda-forge python package does not include debugging symbols on macOS (see [3],[4]), we skip the test for the GDB "libpython" integration and add a simple "Hello World" C program, just to test that the debugger can actually run a program.

We use Travis CI for the macOS build since the conda-forge [Travis macOS image use macOS 10.13 ('xcode9.4')][5]. When tested under Azure and Travis under macOS 10.14 and 10.15, the build phase succeeds but when running the executable in GDB, GDB hangs. Doing manual testing on 10.15.5 I can replicate this behaviour about half the time I `run` an executable in GDB, so it looks like a race condition.

This is probably due to an [intermittent GDB bug][6]. The bug reporter suggests a patch that makes GDB not hang, but fails to launch the executable instead (again, about half the time it still works correctly). I've added this patch to the recipe and added a mention of that in `$PREFIX/.messages.txt` to inform users to just try again if they hit this bug:
```
Intermittent GDB error on Mojave and later
------------------------------------------
We've detected you are running macOS Mojave or later. GDB has a known intermittent bug on
recent macOS versions, see: https://sourceware.org/bugzilla/show_bug.cgi?id=24069

If you receive the following error when running your executable in GDB:

  During startup program terminated with signal ?, Unknown signal

simply try to `run` your executable again, it should work eventually.
```

We also add a README in the recipe dir to warn maintainers and contributors that it's possible that the automated testing starts failing when the Travis CI macOS 10.13 image is decommissioned (by Travis or conda-forge).

[1]: https://github.com/llvm/llvm-project/blob/master/lldb/scripts/macos-setup-codesign.sh
[2]: https://sourceware.org/gdb/wiki/PermissionsDarwin
[3]: https://github.com/conda-forge/gdb-feedstock/pull/23/#issuecomment-643008755
[4]: https://github.com/conda-forge/python-feedstock/issues/354
[5]: https://docs.travis-ci.com/user/reference/osx/
[6]: https://conda-forge.org/docs/maintainer/infrastructure.html?highlight=skip#using-azure-for-everything