### PR TITLE
Add back the python extension

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Download the right script to debug python processes.
+# This is an useful script provided by CPython project to help debugging
+# crashes in Python processes.
+# See https://devguide.python.org/gdb for some
+# examples on how to use it.
+#
+# Normally someone needs to download this script manually and properly
+# setup gdb to load it (if you are lucky gdb was compiled with python
+# support).
+#
+# Providing this in conda-forge's gdb makes the experience much smoother,
+# avoiding all the hassles someone can find when trying to configure gdb
+# for that.
+curl -SL https://raw.githubusercontent.com/python/cpython/$PY_VER/Tools/gdb/libpython.py \
+    > "$SP_DIR/libpython.py"
 
 # Install a gdbinit file that will be automatically loaded
 mkdir -p "$PREFIX/etc"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 360cd7ae79b776988e89d8f9a01c985d0b1fa21c767a4295e5f88cb49175c555
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win or osx]
 
 requirements:

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash -ex
+
+# This test tries to simulate a crash on a python process. The process under test
+# forces a crash by emitting a SIGSEGV signal to itself. This is similar to what
+# would happen on a python code calling a C/C++ module which causes a seg fault.
+# When that happens we should be able to use the python extensions for gdb to get
+# a nicer stack trace (instead of getting cryptic frames with CPython internals).
+#
+# To test that, we just run the process using gdb, let it crash and try to use the
+# py-bt command to print the Python stack trace. This command is provided by CPython
+# repository.
+#
+# You can find more about it:
+#
+# - https://github.com/python/cpython/blob/master/Tools/gdb/libpython.py
+# - https://devguide.python.org/gdb
+
+echo "CONDA_PY:$CONDA_PY"
+export CONDA_PY=`python -c "import sys;print('%s%s'%sys.version_info[:2])"`
+echo "CONDA_PY:$CONDA_PY"
+
+gdb -batch -ex "run" -ex "py-bt" --args python "$RECIPE_DIR/testing/process_to_debug.py" | tee gdb_output
+if [[ "$CONDA_PY" != "27" ]]; then
+    grep "built-in method kill" gdb_output
+fi
+
+# Unfortunately some python packages do not have enough debug info for py-bt
+#
+# This happens because conda-forge only provides packages with all optimizations enabled.
+# Depending on Python's and gdb version, the debug info present on those binaries are not
+# enough to for the libpython.py extension. If the Python version one wants to debug falls
+# into this list, they would have to rebuild the python package locally tweaking -O and -g
+# flags in Python recipe build script.
+#
+# This list is mostly for documentation purposes, so we know exactly which versions can be
+# debugged out-of-the-box with this gdb package. When things change, there is not much to be
+# done besides adding or removing versions from this list.
+insufficient_debug_info_versions=("27" "36")
+
+if [[ " ${insufficient_debug_info_versions[@]} " =~ " ${CONDA_PY} " ]]; then
+    if grep "line 3" gdb_output; then
+        echo "This test was expected to fail due to missing debug info in python"
+        echo "As it passed the test should be re-enabled"
+        exit 1
+    fi
+else
+    # We are lucky! This Python version has enough debug info for us to easily identify
+    # the exact Python code where the crash happened.
+    grep "line 3" gdb_output
+    grep "process_to_debug.py" gdb_output
+    grep 'os.kill(os.getpid(), signal.SIGSEGV)' gdb_output
+fi
+
+grep "Program received signal SIGSEGV" gdb_output

--- a/recipe/testing/process_to_debug.py
+++ b/recipe/testing/process_to_debug.py
@@ -1,0 +1,3 @@
+import os
+import signal
+os.kill(os.getpid(), signal.SIGSEGV)


### PR DESCRIPTION
**NOTE**: This was removed by mistake in https://github.com/conda-forge/gdb-feedstock/pull/27

This is an useful script provided by CPython project to help debugging
crashes in Python processes.

Normally someone needs to download this script manually and properly
setup gdb to load it (if you are lucky gdb was compiled with python
support).

Providing this in conda-forge's gdb makes the experience much smoother,
avoiding all the hassles someone can find when trying to configure gdb
for that.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
