### PR TITLE
Bump build number to force upload

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 360cd7ae79b776988e89d8f9a01c985d0b1fa21c767a4295e5f88cb49175c555
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win or osx]
 
 requirements:


### PR DESCRIPTION
It seems another package was uploaded with build number 1
with a different label:

From https://anaconda.org/conda-forge/gdb/files

```
conda | 4.8 MB | \|                              osx-64/gdb-9.2-py37h1339c39_1.tar.bz2 | 7 hours and 35 minutes ago | cf-staging | 0 | testing
  | conda | 4.8 MB | \|                              osx-64/gdb-9.2-py36h6b2b209_1.tar.bz2 | 7 hours and 36 minutes ago | cf-staging | 0 | testing
  | conda | 4.8 MB | \|                              osx-64/gdb-9.2-py38h73464fe_1.tar.bz2 | 7 hours and 36 minutes ago | cf-staging | 0 | testing
  | conda | 5.5 MB | \|                              linux-64/gdb-9.2-py38h4e60b95_1.tar.bz2 | 7 hours and 41 minutes ago | cf-staging | 0 | testing
  | conda | 5.5 MB | \|                              linux-64/gdb-9.2-py36ha856720_1.tar.bz2 | 7 hours and 42 minutes ago | cf-staging | 0 | testing
  | conda | 5.6 MB | \|                              linux-64/gdb-9.2-py37h7d4168f_1.tar.bz2 | 7 hours and 42 minutes ago | cf-staging | 0 |  

```

This seems to be preventing the
version on master to be uploaded.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
